### PR TITLE
Fix tooth numbering

### DIFF
--- a/src/Odontogram.tsx
+++ b/src/Odontogram.tsx
@@ -400,9 +400,9 @@ export const Odontogram: FC<OdontogramProps> = ({
 			>
 				<title>Odontogram</title>
 
-				{visibleQuadrants.map(({ name, transform, label }, index) => (
+				{visibleQuadrants.map(({ name, transform, prefix }) => (
 					<g key={name} transform={transform}>
-						{renderTeeth(`teeth-${index + 1}`)}
+						{renderTeeth(`teeth-${prefix}`)}
 					</g>
 				))}
 			</svg>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,26 +52,31 @@ export const quadrants: Array<{
 	name: "first" | "second" | "third" | "fourth";
 	transform: string;
 	label: string;
+	prefix: string;
 }> = [
 	{
 		name: "first",
 		transform: "",
-		label: "Upper Right",
+		label: "Upper Left",
+		prefix: "1",
 	},
 	{
 		name: "second",
 		transform: "translate(840, 0) scale(-1, 1) translate(-55,0)",
-		label: "Upper Left",
+		label: "Upper Right",
+		prefix: "2",
 	},
 	{
 		name: "third",
-		transform: "scale(1, -1) translate(0, -150)",
+		transform: "translate(840, 0) scale(-1, -1) translate(-55,-150)",
 		label: "Lower Right",
+		prefix: "3",
 	},
 	{
 		name: "fourth",
-		transform: "translate(840, 0) scale(-1, -1) translate(-55,-150)",
+		transform: "scale(1, -1) translate(0, -150)",
 		label: "Lower Left",
+		prefix: "4",
 	},
 ];
 
@@ -79,26 +84,31 @@ export const oldquadrants: Array<{
 	name: "first" | "second" | "third" | "fourth";
 	transform: string;
 	label: string;
+	prefix: string;
 }> = [
 	{
 		name: "first",
 		transform: "",
-		label: "Upper Right",
+		label: "Upper Left",
+		prefix: "1",
 	},
 	{
 		name: "second",
 		transform: "scale(-1, 1) translate(-409, 0)",
-		label: "Upper Left",
-	},
-	{
-		name: "third",
-		transform: "scale(1, -1) translate(0, -694)",
-		label: "Lower Right",
+		label: "Upper Right",
+		prefix: "2",
 	},
 	{
 		name: "fourth",
 		transform: "scale(-1, -1) translate(-409, -694)",
-		label: "Lower Left",
+		label: "Lower Right",
+		prefix: "3",
+	},
+	{
+		name: "third",
+		transform: "scale(1, -1) translate(0, -694)",
+		label: "Lower left",
+		prefix: "4",
 	},
 ];
 


### PR DESCRIPTION
Hey there, great package you made, keep it up, man.
I just noticed one major issue: the way you're mapping the FDI tooth numbering is flawed. This is from your storybook example:
<img width="411" height="532" alt="image" src="https://github.com/user-attachments/assets/f4dd185b-6224-49c9-85fe-0db1592ecb72" />

You see, this should be `48` and not `38`. This issue goes for the whole lower jaw, and also, if you only show the lower jaw, the numbers are wrong again:

<img width="422" height="265" alt="image" src="https://github.com/user-attachments/assets/15e7577e-425b-45ba-b444-3155703b586f" />

I fixed this issue in this PR. It looks like your code labels some pairs of teeth as "upper left" when they're actually styled to be "upper right".

I also fixed the issue that I mentioned above by examples, by hard-coding the prefix inside each quadrant, because the main reason that the mapping was going wrong was because you were relying on `index` which is not a good idea.


