### PR TITLE
Fix lefthook commands being path dependent

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,10 +2,10 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      run: /opt/homebrew/bin/pnpm lint
+      run: pnpm lint
     typecheck:
-      run: /opt/homebrew/bin/pnpm tsc
+      run: pnpm tsc
     build:
-      run: /opt/homebrew/bin/pnpm build
+      run: pnpm build
     test:
-      run: /opt/homebrew/bin/pnpm test:ci
+      run: pnpm test:ci

--- a/package.json
+++ b/package.json
@@ -52,13 +52,8 @@
 		},
 		"./style.css": "./dist/index.css"
 	},
-	"sideEffects": [
-		"*.css",
-		"**/*.css"
-	],
-	"files": [
-		"dist"
-	],
+	"sideEffects": ["*.css", "**/*.css"],
+	"files": ["dist"],
 	"config": {
 		"commitizen": {
 			"path": "./node_modules/@ryansonshine/cz-conventional-changelog"


### PR DESCRIPTION
It's a bad practice to put these commands with their location with them, one might not have homebrew to begin with (e.g., using another OS), and also one might not have installed the tool in the path you provided (e.g., their pnpm might live in their home directory) 
<img width="347" height="226" alt="image" src="https://github.com/user-attachments/assets/b3ba81e7-50e5-4c0f-8212-7f96916d7043" />
